### PR TITLE
Fix bug in function

### DIFF
--- a/R/fetch_uniprot.R
+++ b/R/fetch_uniprot.R
@@ -79,7 +79,7 @@ fetch_uniprot <-
     
     new_ids <- new$new
     
-    if(is.null(new_ids)) {return(result)}
+    if(all.equal(new_ids, logical(0)) == TRUE) {return(result)}
     
     new_id_query <- paste(paste0("id:", new_ids), collapse = "+or+")
     new_query_url <- utils::URLencode(paste0(url, new_id_query, "&format=tab&columns=",


### PR DESCRIPTION
In the rescue of new ID assignments in the function, the logical test of `new_ids` was never NULL but could be logical(0). Thus, the result was always FALSE and it tried to fetch empty IDs in case of logical(0).
This should be fixed now by using `all.equal(new_ids, logical(0)) == TRUE` instead of `is.null(new_ids)`