### PR TITLE
Require all 3 amino acids

### DIFF
--- a/R/assign_peptide_type.R
+++ b/R/assign_peptide_type.R
@@ -54,6 +54,11 @@ assign_peptide_type <- function(data,
                                 aa_before = aa_before,
                                 last_aa = last_aa,
                                 aa_after = aa_after) {
+
+  if (missing(aa_before) | missing(last_aa) | missing(aa_after)) {
+    stop("Please provide all 3 required amino acids (aa_before, last_aa and aa_after).")
+  }
+  
   data %>%
     dplyr::mutate(N_term_tryp = dplyr::if_else({{ aa_before }} == "" |
       {{ aa_before }} == "K" |

--- a/tests/testthat/test-auxiliary_functions.R
+++ b/tests/testthat/test-auxiliary_functions.R
@@ -42,7 +42,7 @@ if (Sys.getenv("TEST_PROTTI") == "true") {
         protein_sequence = protein_sequence,
         peptide_sequence = peptide
       ) %>%
-      assign_peptide_type(aa_before = aa_before, last_aa = last_aa)
+      assign_peptide_type(aa_before = aa_before, last_aa = last_aa, aa_after = aa_after)
 
     test_that("find_peptide and assign_peptide_type work", {
       expect_is(assigned_types, "data.frame")

--- a/tests/testthat/test-auxiliary_functions.R
+++ b/tests/testthat/test-auxiliary_functions.R
@@ -29,7 +29,7 @@ if (Sys.getenv("TEST_PROTTI") == "true") {
             protein_sequence = protein_sequence,
             peptide_sequence = peptide
           ) %>%
-          peptide_type(aa_before = aa_before, last_aa = last_aa))
+          peptide_type(aa_before = aa_before, last_aa = last_aa, aa_after = aa_after))
       })
       expect_is(assigned_types, "data.frame")
       expect_equal(nrow(assigned_types), 3)


### PR DESCRIPTION
Function `assign_peptide_type()` should now fail if not all 3 amino acids (aa_before, last_aa, aa_after) are provided. 