### PR TITLE
dont check donttest examples

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
+    branches: all
 
 name: R-CMD-check
 
@@ -29,6 +29,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
       TEST_PROTTI: true
       BUILD_VIGNETTE: true
+      R_CHECK_DONTTEST_EXAMPLES: false
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -50,3 +50,4 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
+


### PR DESCRIPTION
set environment variable so donttest examples are not run (can sometimes happen because of the R version etc..)
run github actions on all branches when a PR is created