### PR TITLE
Fetch uniprot 252

### DIFF
--- a/R/fetch_uniprot.R
+++ b/R/fetch_uniprot.R
@@ -53,7 +53,8 @@ fetch_uniprot <-
              "xref_pdb"
            ),
            batchsize = 200,
-           show_progress = TRUE) {
+           show_progress = TRUE,
+           ...) {
     if (!curl::has_internet()) {
       message("No internet connection.")
       return(invisible(NULL))
@@ -125,7 +126,7 @@ They were fetched and the original input ID can be found in the "input_id" colum
         collapsed_columns
       ))
 
-      query <- try_query(query_url, progress = FALSE, show_col_types = FALSE)
+      query <- try_query(query_url, progress = FALSE, show_col_types = FALSE, ...)
 
       if (show_progress == TRUE) {
         pb$tick()

--- a/R/fetch_uniprot_proteome.R
+++ b/R/fetch_uniprot_proteome.R
@@ -24,7 +24,8 @@
 fetch_uniprot_proteome <-
   function(organism_id,
            columns = c("accession"),
-           reviewed = TRUE) {
+           reviewed = TRUE,
+           ...) {
     if (length(organism_id) == 0) {
       stop("No valid organism ID found.")
     }
@@ -47,7 +48,7 @@ fetch_uniprot_proteome <-
         "&format=tsv&fields=",
         collapsed_columns
       ))
-    result <- try_query(query_url, progress = FALSE, show_col_types = FALSE)
+    result <- try_query(query_url, progress = FALSE, show_col_types = FALSE, ...)
     # result can either be a data.frame or it is a character string with the error message
     if (!methods::is(result, "data.frame")) {
       return(invisible(result))

--- a/R/try_query.R
+++ b/R/try_query.R
@@ -43,7 +43,6 @@ try_query <-
     retry_delay <- 3
 
     while (!is(query_result, "response") && try_n < max_tries) {
-
       query_result <- tryCatch(
         {
           if (!missing(accept)) {
@@ -67,7 +66,7 @@ try_query <-
 
       try_n <- try_n + 1
       Sys.sleep(retry_delay)
-      retry_delay <- retry_delay * 2  # Exponential backoff
+      retry_delay <- retry_delay * 2 # Exponential backoff
     }
 
 


### PR DESCRIPTION
closes #252  (hopefully)

![Screenshot 2024-05-23 at 18 11 15](https://github.com/jpquast/protti/assets/70535771/82844ab6-5f63-46c5-b888-f0ab50787f43)

i added more verbos error messages and implemented a retry_delay (can be helpful in case UniProt API has rate limits, reduced server load)

plus, its now possible to pass the timeout/max_tries parameters from the fetch_uniprot function to try_query

i test on fetch_uniprot_proteome(9606) and it was usually working after the second attempt - but would be great if you test it as well 
